### PR TITLE
Instrument show owner edits

### DIFF
--- a/app/controllers/instruments_controller.rb
+++ b/app/controllers/instruments_controller.rb
@@ -52,6 +52,8 @@ class InstrumentsController < ApplicationController
   end
 
   def destroy
+    @instrument.destroy
+    redirect_to dashboard_path, notice: "Instrument deleted."
   end
 
   def distance_from_user(instrument)

--- a/app/controllers/instruments_controller.rb
+++ b/app/controllers/instruments_controller.rb
@@ -17,6 +17,9 @@ class InstrumentsController < ApplicationController
     @instrument_bookings = booked_dates(@instrument.bookings)
     @booking = Booking.new
     @distance = distance_from_user(@instrument)
+    # 1. test whether logged in user == instrument.user
+    @my_instrument = (@user == current_user)
+    # 2. if true, render buttons for edit and destroy
   end
 
   def new

--- a/app/javascript/controllers/datepicker_controller.js
+++ b/app/javascript/controllers/datepicker_controller.js
@@ -7,7 +7,6 @@ export default class extends Controller {
   }
 
   connect() {
-    console.log(this.bookingsValue)
     flatpickr(this.element, {
       dateFormat: "Y-m-d",
       disable: this.bookingsValue

--- a/app/views/instruments/_booking_form.html.erb
+++ b/app/views/instruments/_booking_form.html.erb
@@ -1,7 +1,11 @@
 <%= simple_form_for [instrument, booking] do |f| %>
   <div class="form-inputs">
   <%= f.input :start_date, as: :string,
-  input_html: { data: { controller: "datepicker", mode: "range", 'datepicker-bookings-value': @instrument_bookings } } %>
+  input_html: { data: {
+    controller: "datepicker",
+    mode: "range",
+    'datepicker-bookings-value': @instrument_bookings
+    } } %>
   </div>
   <div class="form-actions">
   <%= f.button :submit %>

--- a/app/views/instruments/show.html.erb
+++ b/app/views/instruments/show.html.erb
@@ -4,15 +4,9 @@
     <%= image_tag @instrument.image_url, alt: "Image of #{@instrument.category}", height: 400 %>
   </div>
   <div class="col-5">
-    <h2>
-      <%= @instrument.model %>, <%= @instrument.brand %>
-    </h2>
-    <h3>
-      Located in <%= @instrument.city %> for <%= @instrument.daily_price.to_i %> € per day.
-    </h3>
-    <p>
-      Description: <%= @instrument.description %>
-    </p>
+    <h2><%= @instrument.model %>, <%= @instrument.brand %></h2>
+    <h3>Located in <%= @instrument.city %> for <%= @instrument.daily_price.to_i %> € per day.</h3>
+    <p>Description: <%= @instrument.description %></p>
     <% if @my_instrument %>
       <%= link_to 'Edit Instrument', edit_instrument_path(@instrument) %>
       <%= link_to 'Delete Instrument',
@@ -25,13 +19,10 @@
         </div>
       </div>
     <% else %>
-      <p>
-        Distance from you: <%= @distance %> km
-      </p>
+      <p>Distance from you: <%= @distance %> km</p>
       <div data-controller="toggle" class="mt-5">
       <button data-action="click->toggle#fire" class="btn btn-outline-primary">Book me!</button>
-      <div data-toggle-target="togglableElement" class="d-none">
-        <%= render 'booking_form', booking: @booking, instrument: @instrument, instrument_bookings: @instrument_bookings %>
+      <div data-toggle-target="togglableElement" class="d-none"><%= render 'booking_form', booking: @booking, instrument: @instrument, instrument_bookings: @instrument_bookings %>
       </div>
       </div>
     <% end %>

--- a/app/views/instruments/show.html.erb
+++ b/app/views/instruments/show.html.erb
@@ -1,12 +1,13 @@
 <h1>A <%= @instrument.category %> offered by <%= @user.first_name %> <%= @user.last_name[0] %>.</h1>
-<div class="row justify-content-around">
-  <div class="col-5 justify-content-center">
+<div class="row justify-content-center">
+  <div class="col-5 justify-content-end">
     <%= image_tag @instrument.image_url, alt: "Image of #{@instrument.category}", height: 400 %>
   </div>
   <div class="col-5">
     <h2>
       <%= @instrument.model %>, <%= @instrument.brand %>
     </h2>
+    <h2>This is my instrument <%= @my_instrument %></h2>
     <h3>
       Located in <%= @instrument.city %> for <%= @instrument.daily_price.to_i %> € per day.
     </h3>
@@ -18,9 +19,8 @@
     </p>
     <div data-controller="toggle" class="mt-5">
       <button data-action="click->toggle#fire" class="btn btn-outline-primary">Book me!</button>
-    </div>
-    <div data-toggle-target="togglableElement" class="d-none">
-      <%= render 'booking_form', booking: @booking, instrument: @instrument, instrument_bookings: @instrument_bookings %>
-    </div>
+      <div data-toggle-target="togglableElement" class="d-none">
+        <%= render 'booking_form', booking: @booking, instrument: @instrument, instrument_bookings: @instrument_bookings %>
+      </div>
   </div>
 </div>

--- a/app/views/instruments/show.html.erb
+++ b/app/views/instruments/show.html.erb
@@ -7,20 +7,32 @@
     <h2>
       <%= @instrument.model %>, <%= @instrument.brand %>
     </h2>
-    <h2>This is my instrument <%= @my_instrument %></h2>
     <h3>
       Located in <%= @instrument.city %> for <%= @instrument.daily_price.to_i %> € per day.
     </h3>
     <p>
       Description: <%= @instrument.description %>
     </p>
-    <p>
-      Distance from you: <%= @distance %> km
-    </p>
-    <div data-controller="toggle" class="mt-5">
+    <% if @my_instrument %>
+      <%= link_to 'Edit Instrument', edit_instrument_path(@instrument) %>
+      <%= link_to 'Delete Instrument',
+        instrument_path(@instrument), html_options = {
+          data: {turbo_method: :delete, turbo_confirm: "Are you sure you want to delete this #{@instrument.category}?"} } %>
+      <div data-controller="toggle" class="mt-5">
+        <button data-action="click->toggle#fire" class="btn btn-outline-primary">Schedule Unavailability</button>
+        <div data-toggle-target="togglableElement" class="d-none">
+          <%= render 'booking_form', booking: @booking, instrument: @instrument, instrument_bookings: @instrument_bookings %>
+        </div>
+      </div>
+    <% else %>
+      <p>
+        Distance from you: <%= @distance %> km
+      </p>
+      <div data-controller="toggle" class="mt-5">
       <button data-action="click->toggle#fire" class="btn btn-outline-primary">Book me!</button>
       <div data-toggle-target="togglableElement" class="d-none">
         <%= render 'booking_form', booking: @booking, instrument: @instrument, instrument_bookings: @instrument_bookings %>
       </div>
-  </div>
+      </div>
+    <% end %>
 </div>

--- a/app/views/instruments/show.html.erb
+++ b/app/views/instruments/show.html.erb
@@ -1,29 +1,26 @@
 <h1>A <%= @instrument.category %> offered by <%= @user.first_name %> <%= @user.last_name[0] %>.</h1>
-<div class="d-flex align-contents-center">
-  <div class="col-5">
+<div class="row justify-content-around">
+  <div class="col-5 justify-content-center">
     <%= image_tag @instrument.image_url, alt: "Image of #{@instrument.category}", height: 400 %>
   </div>
   <div class="col-5">
     <h2>
       <%= @instrument.model %>, <%= @instrument.brand %>
     </h2>
-    <p><%= @instrument_bookings %></p>
     <h3>
-      Located in <%= @instrument.city %> for <%= @instrument.daily_price %> per day.
+      Located in <%= @instrument.city %> for <%= @instrument.daily_price.to_i %> € per day.
     </h3>
     <p>
       Description: <%= @instrument.description %>
     </p>
     <p>
-      Distance from you: <%= @distance %> Km.
+      Distance from you: <%= @distance %> km
     </p>
     <div data-controller="toggle" class="mt-5">
-    <button data-action="click->toggle#fire" class="btn btn-outline-primary">Book me!</button>
+      <button data-action="click->toggle#fire" class="btn btn-outline-primary">Book me!</button>
+    </div>
     <div data-toggle-target="togglableElement" class="d-none">
-    <%= render 'booking_form', booking: @booking, instrument: @instrument, instrument_bookings: @instrument_bookings %>
+      <%= render 'booking_form', booking: @booking, instrument: @instrument, instrument_bookings: @instrument_bookings %>
     </div>
   </div>
-    <%# <%= render 'booking_form', booking: @booking, instrument: @instrument %>
-  </div>
 </div>
-<%# <%= render 'layouts/booking_inspect', instrument: @instrument, booking: @instrument_bookings.last %>


### PR DESCRIPTION
Adds contextually appropriate information to instrument show page: 
Owners see options for listing their instrument as unavailable, editing its details, deleting it from system
Visitors see how far away the instrument is from them and the option to make a booking