### PR TITLE
Model refactor

### DIFF
--- a/app/controllers/instruments_controller.rb
+++ b/app/controllers/instruments_controller.rb
@@ -13,7 +13,7 @@ class InstrumentsController < ApplicationController
     if params[:dates].present?
       @start_date = Date.parse(params[:dates].split(" to ").first)
       @end_date = Date.parse(params[:dates].split(" to ").last)
-      @instruments = Instrument.where.not(id: Booking.unavailable(@start_date, @end_date).pluck(:instrument_id))
+      @instruments = Instrument.available_between(@start_date, @end_date)
     end
     if params[:distance].present? && params[:distance].to_i != 100 && current_user.present?
       @instruments = @instruments.near([current_user.latitude, current_user.longitude], params[:distance], units: :km)

--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -9,35 +9,6 @@ class Booking < ApplicationRecord
   # calls no_booking_overlap method
   validate :no_booking_overlap
 
-  # Runs Booking.where
-  # Returns array of Bookings that would overlap with dates
-  # If the array is empty there are no conflicts
-  # If the array is not empty there are conflicts
-  # def self.overlapping(new_booking_start_date, new_booking_end_date, new_booking_instrument_id)
-  #   where "
-  #   instrument_id = :instrument_id AND 
-  #   (
-  #     (
-  #       start_date <= :start_date AND
-  #       end_date >= :start_date
-  #     ) OR (
-  #       start_date <= :end_date AND
-  #       end_date >= :end_date
-  #     )
-  #   )", start_date: new_booking_start_date, end_date: new_booking_end_date, instrument_id: new_booking_instrument_id
-  # end
-
-  # def self.unavailable(new_booking_start_date, new_booking_end_date)
-  #   where "
-  #   (
-  #     start_date <= :start_date AND
-  #     end_date >= :start_date
-  #   ) OR (
-  #     start_date <= :end_date AND
-  #     end_date >= :end_date
-  #   )", start_date: new_booking_start_date, end_date: new_booking_end_date
-  # end
-
   def self.overlapping(new_booking_start_date, new_booking_end_date)
     where("
           (

--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -13,35 +13,48 @@ class Booking < ApplicationRecord
   # Returns array of Bookings that would overlap with dates
   # If the array is empty there are no conflicts
   # If the array is not empty there are conflicts
-  def self.overlapping(new_booking_start_date, new_booking_end_date, new_booking_instrument_id)
-    where "
-    instrument_id = :instrument_id AND (
-      (
-        start_date <= :start_date AND
-        end_date >= :start_date
-      ) OR (
-        start_date <= :end_date AND
-        end_date >= :end_date
-      )
-    )", start_date: new_booking_start_date, end_date: new_booking_end_date, instrument_id: new_booking_instrument_id
-  end
+  # def self.overlapping(new_booking_start_date, new_booking_end_date, new_booking_instrument_id)
+  #   where "
+  #   instrument_id = :instrument_id AND 
+  #   (
+  #     (
+  #       start_date <= :start_date AND
+  #       end_date >= :start_date
+  #     ) OR (
+  #       start_date <= :end_date AND
+  #       end_date >= :end_date
+  #     )
+  #   )", start_date: new_booking_start_date, end_date: new_booking_end_date, instrument_id: new_booking_instrument_id
+  # end
 
-  def self.unavailable(new_booking_start_date, new_booking_end_date)
-    where "
-    (
-      start_date <= :start_date AND
-      end_date >= :start_date
-    ) OR (
-      start_date <= :end_date AND
-      end_date >= :end_date
-    )", start_date: new_booking_start_date, end_date: new_booking_end_date
+  # def self.unavailable(new_booking_start_date, new_booking_end_date)
+  #   where "
+  #   (
+  #     start_date <= :start_date AND
+  #     end_date >= :start_date
+  #   ) OR (
+  #     start_date <= :end_date AND
+  #     end_date >= :end_date
+  #   )", start_date: new_booking_start_date, end_date: new_booking_end_date
+  # end
+
+  def self.overlapping(new_booking_start_date, new_booking_end_date)
+    where("
+          (
+            :start_date BETWEEN start_date AND end_date
+          ) OR (
+            :end_date BETWEEN start_date AND end_date
+          ) OR (
+            start_date >= :start_date AND end_date <= :end_date
+          )
+          ", start_date: new_booking_start_date, end_date: new_booking_end_date)
   end
 
   private
 
   def no_booking_overlap
     # Guard clause
-    return true if Booking.overlapping(start_date, end_date, instrument_id).none?
+    return true if instrument.bookings.overlapping(start_date, end_date).none?
 
     # else
     errors.add(:start_date, 'it overlaps another reservation')

--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -3,15 +3,25 @@ class Instrument < ApplicationRecord
   has_many :bookings, dependent: :destroy
 
   include PgSearch::Model
-  pg_search_scope :search,
-                  against: %i[model brand category description city],
-                  using: {
-                    tsearch: { prefix: true }
-                  }
+  pg_search_scope(
+    :search,
+    against: %i[model brand category description city],
+    using: {
+      tsearch: { prefix: true }
+    }
+  )
 
   validates :category, :daily_price, :image_url, :city, presence: true
   validates :daily_price, numericality: { greater_than: 0 }
 
   geocoded_by :city
   after_validation :geocode, if: :will_save_change_to_city?
+
+  def self.unavailable_between(start_date, end_date)
+    joins(:bookings).merge(Booking.overlapping(start_date, end_date))
+  end
+
+  def self.available_between(start_date, end_date)
+    where.not(id: unavailable_between(start_date, end_date).pluck(:id))
+  end
 end


### PR DESCRIPTION
Instrument has 2 new methods
- Instrument.available_between(start_date, end_date)
- Instrument.unavailable_between(start_date, end_date)

Fixes bug where Booking would be valid if currently existed bookings were between new booking dates
e.g. a booking from 2023-08-24 - 2023-09-30 would have been valid if a previously existing booking from 2023-08-29 - 2023-08-30 was present